### PR TITLE
Enable parsing from strings and rely on coroutines

### DIFF
--- a/Assets/Scripts/RuntimeScripts/RuntimeTextScriptController.cs
+++ b/Assets/Scripts/RuntimeScripts/RuntimeTextScriptController.cs
@@ -41,6 +41,23 @@ namespace RuntimeScripting
             }
         }
 
+        /// <summary>
+        /// Loads script events from a string.
+        /// </summary>
+        /// <param name="script">Script contents in the DSL format.</param>
+        public void LoadFromString(string script)
+        {
+            events.Clear();
+            var loaded = TextScriptParser.ParseString(script);
+            foreach (var kv in loaded)
+            {
+                if (!events.ContainsKey(kv.Key))
+                    events[kv.Key] = kv.Value;
+                else
+                    events[kv.Key].Actions.AddRange(kv.Value.Actions);
+            }
+        }
+
         public void Trigger(string eventName)
         {
             if (!events.TryGetValue(eventName, out var pe))
@@ -63,15 +80,6 @@ namespace RuntimeScripting
                 {
                     ExecuteActionImmediately(param);
                 }
-            }
-        }
-
-        public void Update(float delta)
-        {
-            for (int i = scheduled.Count - 1; i >= 0; i--)
-            {
-                if (!scheduled[i].Update(delta))
-                    scheduled.RemoveAt(i);
             }
         }
 

--- a/Assets/Scripts/RuntimeScripts/ScheduledAction.cs
+++ b/Assets/Scripts/RuntimeScripts/ScheduledAction.cs
@@ -24,30 +24,6 @@ namespace RuntimeScripting
         }
 
         /// <summary>
-        /// Updates the internal timer and executes if interval elapsed.
-        /// </summary>
-        /// <param name="delta">Delta time in seconds.</param>
-        /// <returns>True if still active.</returns>
-        public bool Update(float delta)
-        {
-            elapsed += delta;
-            if (parsed.Period > 0 && elapsed > parsed.Period)
-            {
-                return false;
-            }
-
-            if (elapsed >= nextTime)
-            {
-                if (string.IsNullOrEmpty(parsed.CanExecuteRaw) || ConditionEvaluator.Evaluate(parsed.CanExecuteRaw, controller.GameLogic))
-                {
-                    controller.ExecuteActionImmediately(param);
-                }
-                nextTime = elapsed + (parsed.Interval > 0 ? parsed.Interval : EvaluateInterval());
-            }
-            return true;
-        }
-
-        /// <summary>
         /// Coroutine execution handling intervals automatically.
         /// </summary>
         public IEnumerator ExecuteCoroutine()

--- a/Assets/Scripts/RuntimeScripts/TextScriptParser.cs
+++ b/Assets/Scripts/RuntimeScripts/TextScriptParser.cs
@@ -14,7 +14,7 @@ namespace RuntimeScripting
         private static readonly Regex actionRegex = new Regex(@"(?<name>\w+)\((?<args>[^)]*)\)");
 
         /// <summary>
-        /// Loads all script files and returns a dictionary of ParsedEvents.
+        /// Loads all script files and returns a dictionary of <see cref="ParsedEvent"/> objects.
         /// </summary>
         public static Dictionary<string, ParsedEvent> LoadScripts(string folder)
         {
@@ -26,11 +26,28 @@ namespace RuntimeScripting
             return result;
         }
 
+        /// <summary>
+        /// Parses a single script text and returns its events.
+        /// </summary>
+        /// <param name="script">The script contents.</param>
+        public static Dictionary<string, ParsedEvent> ParseString(string script)
+        {
+            var result = new Dictionary<string, ParsedEvent>();
+            var lines = script.Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries);
+            ParseLines(lines, result);
+            return result;
+        }
+
         private static void ParseFile(string path, Dictionary<string, ParsedEvent> events)
+        {
+            var lines = File.ReadAllLines(path);
+            ParseLines(lines, events);
+        }
+
+        private static void ParseLines(IEnumerable<string> lines, Dictionary<string, ParsedEvent> events)
         {
             string currentEvent = null;
             ParsedEvent parsedEvent = null;
-            var lines = File.ReadAllLines(path);
             foreach (var raw in lines)
             {
                 var line = raw.Trim();


### PR DESCRIPTION
## Summary
- add `ParseString` helper in `TextScriptParser`
- add `LoadFromString` in `RuntimeTextScriptController`
- remove all `Update` methods, relying on coroutines for scheduled actions

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68405da89cf083308483855a7d45e519