### PR TITLE
Add single file loading

### DIFF
--- a/Assets/Scripts/RuntimeScripts/RuntimeTextScriptController.cs
+++ b/Assets/Scripts/RuntimeScripts/RuntimeTextScriptController.cs
@@ -30,15 +30,18 @@ namespace RuntimeScripting
 
         public void Load(string folder)
         {
-            events.Clear();
             var loaded = TextScriptParser.LoadScripts(folder);
-            foreach (var kv in loaded)
-            {
-                if (!events.ContainsKey(kv.Key))
-                    events[kv.Key] = kv.Value;
-                else
-                    events[kv.Key].Actions.AddRange(kv.Value.Actions);
-            }
+            MergeEvents(loaded);
+        }
+
+        /// <summary>
+        /// Loads a single script file.
+        /// </summary>
+        /// <param name="path">Path to the script file.</param>
+        public void LoadFile(string path)
+        {
+            var loaded = TextScriptParser.LoadFile(path);
+            MergeEvents(loaded);
         }
 
         /// <summary>
@@ -47,8 +50,13 @@ namespace RuntimeScripting
         /// <param name="script">Script contents in the DSL format.</param>
         public void LoadFromString(string script)
         {
-            events.Clear();
             var loaded = TextScriptParser.ParseString(script);
+            MergeEvents(loaded);
+        }
+
+        private void MergeEvents(Dictionary<string, ParsedEvent> loaded)
+        {
+            events.Clear();
             foreach (var kv in loaded)
             {
                 if (!events.ContainsKey(kv.Key))

--- a/Assets/Scripts/RuntimeScripts/TextScriptParser.cs
+++ b/Assets/Scripts/RuntimeScripts/TextScriptParser.cs
@@ -27,6 +27,17 @@ namespace RuntimeScripting
         }
 
         /// <summary>
+        /// Loads a single script file and returns its events.
+        /// </summary>
+        /// <param name="path">Path to the script file.</param>
+        public static Dictionary<string, ParsedEvent> LoadFile(string path)
+        {
+            var result = new Dictionary<string, ParsedEvent>();
+            ParseFile(path, result);
+            return result;
+        }
+
+        /// <summary>
         /// Parses a single script text and returns its events.
         /// </summary>
         /// <param name="script">The script contents.</param>


### PR DESCRIPTION
## Summary
- add `LoadFile` method on `TextScriptParser` for single-file parsing
- expose `LoadFile` on `RuntimeTextScriptController`
- refactor loading methods to reduce duplication

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406b49cba88330a2b4b1cf3fb3cab7