### PR TITLE
Switch script loading to Unity Resources

### DIFF
--- a/Assets/Resources/ScriptFiles/OnCombo_AttackComboCount.txt
+++ b/Assets/Resources/ScriptFiles/OnCombo_AttackComboCount.txt
@@ -1,0 +1,2 @@
+[OnCombo]
+Attack(ComboCount())

--- a/Assets/Resources/ScriptFiles/OnCombo_IfCombo10_Invuln30.txt
+++ b/Assets/Resources/ScriptFiles/OnCombo_IfCombo10_Invuln30.txt
@@ -1,0 +1,2 @@
+[OnCombo]
+ComboCount() >= 10: AddPlayerEffectFor(@l, invulnerability, 1, 30)

--- a/Assets/Resources/ScriptFiles/OnEvolutionSummoned_AddSpeed1_AddStrength1.txt
+++ b/Assets/Resources/ScriptFiles/OnEvolutionSummoned_AddSpeed1_AddStrength1.txt
@@ -1,0 +1,3 @@
+[OnEvolutionSummoned]
+AddPlayerEffect(@l, speed, 1)
+AddPlayerEffect(@l, strength, 1)

--- a/Assets/Resources/ScriptFiles/OnEvolutionSummoned_AddStrength1.txt
+++ b/Assets/Resources/ScriptFiles/OnEvolutionSummoned_AddStrength1.txt
@@ -1,0 +1,2 @@
+[OnEvolutionSummoned]
+AddPlayerEffect(@l, strength, 1)

--- a/Assets/Resources/ScriptFiles/OnEvolutionSummoned_RemoveDebuff20.txt
+++ b/Assets/Resources/ScriptFiles/OnEvolutionSummoned_RemoveDebuff20.txt
@@ -1,0 +1,2 @@
+[OnEvolutionSummoned]
+RemoveRandomDebuffPlayerEffect(@l, 20)

--- a/Assets/Resources/ScriptFiles/OnHpChanged_IfHpMin100_Strength10.txt
+++ b/Assets/Resources/ScriptFiles/OnHpChanged_IfHpMin100_Strength10.txt
@@ -1,0 +1,2 @@
+[OnHpChanged]
+HpMin() <= 100: AddPlayerEffect(@l, strength, 10)

--- a/Assets/Resources/ScriptFiles/OnSpawned_AddHp2.interval1.txt
+++ b/Assets/Resources/ScriptFiles/OnSpawned_AddHp2.interval1.txt
@@ -1,0 +1,2 @@
+[OnSpawned]
+AddMaxHp(@l, 2) interval=1

--- a/Assets/Resources/ScriptFiles/OnSpawned_AddSpikes1.interval3.txt
+++ b/Assets/Resources/ScriptFiles/OnSpawned_AddSpikes1.interval3.txt
@@ -1,0 +1,2 @@
+[OnSpawned]
+AddPlayerEffect(@l, spikes, 1) interval=3

--- a/Assets/Resources/ScriptFiles/OnSpawned_Attack5.interval9.txt
+++ b/Assets/Resources/ScriptFiles/OnSpawned_Attack5.interval9.txt
@@ -1,0 +1,2 @@
+[OnSpawned]
+Attack(5) interval=9

--- a/Assets/Resources/ScriptFiles/OnSpawned_Attack50.ifUseSun6.interval3.txt
+++ b/Assets/Resources/ScriptFiles/OnSpawned_Attack50.ifUseSun6.interval3.txt
@@ -1,0 +1,2 @@
+[OnSpawned]
+UseResource(sun,6): Attack(50) interval=3

--- a/Assets/Resources/ScriptFiles/OnSpawned_AttackDynamicCherry.interval2.txt
+++ b/Assets/Resources/ScriptFiles/OnSpawned_AttackDynamicCherry.interval2.txt
@@ -1,0 +1,2 @@
+[OnSpawned]
+Attack(NanikaCount(#a[id=cherry])) interval=2

--- a/Assets/Resources/ScriptFiles/OnSpawned_SetVolt1.interval1.txt
+++ b/Assets/Resources/ScriptFiles/OnSpawned_SetVolt1.interval1.txt
@@ -1,0 +1,2 @@
+[OnSpawned]
+SetNanikaEffectFor(@l, volt, 1) interval=1

--- a/Assets/Resources/ScriptFiles/OnStartRound_AddMaxHp20.txt
+++ b/Assets/Resources/ScriptFiles/OnStartRound_AddMaxHp20.txt
@@ -1,0 +1,2 @@
+[OnStartRound]
+AddMaxHp(@l, 20)

--- a/Assets/Scripts/RuntimeScripts/RuntimeTextScriptController.cs
+++ b/Assets/Scripts/RuntimeScripts/RuntimeTextScriptController.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 namespace RuntimeScripting
 {
     /// <summary>
-    /// Loads script files and triggers events.
+    /// Loads script files from the Resources folder and triggers events.
     /// </summary>
     public class RuntimeTextScriptController : MonoBehaviour
     {
@@ -20,6 +20,10 @@ namespace RuntimeScripting
             GameLogic = gameLogic;
         }
 
+        /// <summary>
+        /// Loads all script files from a Resources folder.
+        /// </summary>
+        /// <param name="folder">Resources subfolder containing the scripts.</param>
         public void Load(string folder)
         {
             var loaded = TextScriptParser.LoadScripts(folder);
@@ -27,9 +31,9 @@ namespace RuntimeScripting
         }
 
         /// <summary>
-        /// Loads a single script file.
+        /// Loads a single script file from the Resources folder.
         /// </summary>
-        /// <param name="path">Path to the script file.</param>
+        /// <param name="path">Resource path of the script without extension.</param>
         public void LoadFile(string path)
         {
             var loaded = TextScriptParser.LoadFile(path);

--- a/Assets/Scripts/RuntimeScripts/TextScriptParser.cs
+++ b/Assets/Scripts/RuntimeScripts/TextScriptParser.cs
@@ -1,12 +1,12 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Text.RegularExpressions;
+using UnityEngine;
 
 namespace RuntimeScripting
 {
     /// <summary>
-    /// Parses script files located under Assets/ScriptFiles.
+    /// Parses script files located under the Resources folder.
     /// </summary>
     public static class TextScriptParser
     {
@@ -19,9 +19,10 @@ namespace RuntimeScripting
         public static Dictionary<string, ParsedEvent> LoadScripts(string folder)
         {
             var result = new Dictionary<string, ParsedEvent>();
-            foreach (var file in Directory.GetFiles(folder, "*.txt"))
+            var assets = Resources.LoadAll<TextAsset>(folder);
+            foreach (var asset in assets)
             {
-                ParseFile(file, result);
+                ParseText(asset.text, result);
             }
             return result;
         }
@@ -51,7 +52,20 @@ namespace RuntimeScripting
 
         private static void ParseFile(string path, Dictionary<string, ParsedEvent> events)
         {
-            var lines = File.ReadAllLines(path);
+            if (path.EndsWith(".txt"))
+                path = path.Substring(0, path.Length - 4);
+            var asset = Resources.Load<TextAsset>(path);
+            if (asset == null)
+            {
+                Debug.LogWarning($"Script file not found: {path}");
+                return;
+            }
+            ParseText(asset.text, events);
+        }
+
+        private static void ParseText(string text, Dictionary<string, ParsedEvent> events)
+        {
+            var lines = text.Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries);
             ParseLines(lines, events);
         }
 


### PR DESCRIPTION
## Summary
- load scripts via `Resources` in `TextScriptParser`
- document Resources usage in `RuntimeTextScriptController`
- copy script text assets into `Assets/Resources/ScriptFiles`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684072e3a27083308a64300e20d4fa2c