### PR TITLE
Use enum definitions for functions

### DIFF
--- a/Assets/Scripts/RuntimeScripts/ConditionEvaluator.cs
+++ b/Assets/Scripts/RuntimeScripts/ConditionEvaluator.cs
@@ -129,6 +129,8 @@ namespace RuntimeScripting
                         }
                     }
                     Expect(TokenType.RParen);
+                    if (Enum.TryParse(func, out FunctionInt f))
+                        return gameLogic.EvaluateFunctionInt(f, args.ToArray());
                     return gameLogic.EvaluateFunctionInt(func, args.ToArray());
                 }
 

--- a/Assets/Scripts/RuntimeScripts/FunctionEnums.cs
+++ b/Assets/Scripts/RuntimeScripts/FunctionEnums.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace RuntimeScripting
+{
+    /// <summary>
+    /// Functions returning integer values.
+    /// </summary>
+    public enum FunctionInt
+    {
+        HpMin,
+        ComboCount,
+        Shield,
+        NanikaCount,
+        UseResource,
+        NotDebuffed
+    }
+
+    /// <summary>
+    /// Functions returning floating point values.
+    /// </summary>
+    public enum FunctionFloat
+    {
+        Interval
+    }
+}

--- a/Assets/Scripts/RuntimeScripts/GameLogic.cs
+++ b/Assets/Scripts/RuntimeScripts/GameLogic.cs
@@ -16,18 +16,25 @@ namespace RuntimeScripting
         public int NanikaCount(string spec) => 0;
         public bool NotDebuffed(string target) => true;
 
-        public int EvaluateFunctionInt(string func, string[] args)
+        public int EvaluateFunctionInt(FunctionInt func, string[] args)
         {
             switch (func)
             {
-                case "HpMin": return HpMin();
-                case "ComboCount": return ComboCount();
-                case "Shield": return Shield();
-                case "NanikaCount": return NanikaCount(args.Length > 0 ? args[0] : string.Empty);
-                case "UseResource": return UseResource(args[0], int.Parse(args[1])) ? 1 : 0;
-                case "NotDebuffed": return NotDebuffed(args[0]) ? 1 : 0;
+                case FunctionInt.HpMin: return HpMin();
+                case FunctionInt.ComboCount: return ComboCount();
+                case FunctionInt.Shield: return Shield();
+                case FunctionInt.NanikaCount: return NanikaCount(args.Length > 0 ? args[0] : string.Empty);
+                case FunctionInt.UseResource: return UseResource(args[0], int.Parse(args[1])) ? 1 : 0;
+                case FunctionInt.NotDebuffed: return NotDebuffed(args[0]) ? 1 : 0;
                 default: return 0;
             }
+        }
+
+        public int EvaluateFunctionInt(string func, string[] args)
+        {
+            if (Enum.TryParse(func, out FunctionInt f))
+                return EvaluateFunctionInt(f, args);
+            return 0;
         }
 
         /// <summary>
@@ -36,17 +43,26 @@ namespace RuntimeScripting
         /// <param name="func">Function name.</param>
         /// <param name="args">Arguments passed from the script.</param>
         /// <returns>Function result as float.</returns>
-        public float EvaluateFunctionFloat(string func, string[] args)
+        public float EvaluateFunctionFloat(FunctionFloat func, string[] args)
         {
             switch (func)
             {
-                case "Interval":
+                case FunctionFloat.Interval:
                     if (args.Length > 0 && float.TryParse(args[0], out float v))
                         return v;
                     return 0f;
                 default:
-                    return EvaluateFunctionInt(func, args);
+                    return 0f;
             }
+        }
+
+        public float EvaluateFunctionFloat(string func, string[] args)
+        {
+            if (Enum.TryParse(func, out FunctionFloat f))
+                return EvaluateFunctionFloat(f, args);
+            if (Enum.TryParse(func, out FunctionInt fi))
+                return EvaluateFunctionInt(fi, args);
+            return 0f;
         }
 
         // Action methods used by RuntimeTextScriptController

--- a/Assets/Scripts/RuntimeScripts/ScheduledAction.cs
+++ b/Assets/Scripts/RuntimeScripts/ScheduledAction.cs
@@ -61,6 +61,8 @@ namespace RuntimeScripting
                     Array.Empty<string>() : argsPart.Split(',');
                 for (int i = 0; i < args.Length; i++)
                     args[i] = args[i].Trim();
+                if (Enum.TryParse(func, out FunctionFloat ff))
+                    return controller.GameLogic.EvaluateFunctionFloat(ff, args);
                 return controller.GameLogic.EvaluateFunctionFloat(func, args);
             }
             return parsed.Interval;


### PR DESCRIPTION
## Summary
- add `FunctionInt` and `FunctionFloat` enums
- use the enums in GameLogic
- update ConditionEvaluator and ScheduledAction to parse function names to enums

## Testing
- `dotnet test` *(fails: `command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68407a8495848330b685631ccf91bef9