### PR TITLE
Re-evaluate parameters for repeating actions

### DIFF
--- a/Assets/Scripts/RuntimeScripts/RuntimeTextScriptController.cs
+++ b/Assets/Scripts/RuntimeScripts/RuntimeTextScriptController.cs
@@ -73,16 +73,16 @@ namespace RuntimeScripting
                 if (!string.IsNullOrEmpty(pa.Condition) && !ConditionEvaluator.Evaluate(pa.Condition, GameLogic))
                     continue;
 
-                var param = Convert(pa);
                 if (pa.Interval > 0 || !string.IsNullOrEmpty(pa.IntervalFuncRaw))
                 {
-                    var sa = new ScheduledAction(param, pa, this);
+                    var sa = new ScheduledAction(pa, this);
                     scheduled.Add(sa);
                     var co = StartCoroutine(RunScheduledAction(sa));
                     running.Add(co);
                 }
                 else
                 {
+                    var param = CreateParameter(pa);
                     ExecuteActionImmediately(param);
                 }
             }
@@ -122,7 +122,7 @@ namespace RuntimeScripting
             }
         }
 
-        private ActionParameter Convert(ParsedAction pa)
+        internal ActionParameter CreateParameter(ParsedAction pa)
         {
             var param = new ActionParameter
             {

--- a/Assets/Scripts/RuntimeScripts/ScheduledAction.cs
+++ b/Assets/Scripts/RuntimeScripts/ScheduledAction.cs
@@ -9,15 +9,13 @@ namespace RuntimeScripting
     /// </summary>
     public class ScheduledAction
     {
-        private readonly ActionParameter param;
         private readonly ParsedAction parsed;
         private readonly RuntimeTextScriptController controller;
         private float elapsed;
         private float nextTime;
 
-        public ScheduledAction(ActionParameter param, ParsedAction parsed, RuntimeTextScriptController controller)
+        public ScheduledAction(ParsedAction parsed, RuntimeTextScriptController controller)
         {
-            this.param = param;
             this.parsed = parsed;
             this.controller = controller;
             nextTime = parsed.Interval > 0 ? parsed.Interval : EvaluateInterval();
@@ -39,6 +37,7 @@ namespace RuntimeScripting
 
                 if (string.IsNullOrEmpty(parsed.CanExecuteRaw) || ConditionEvaluator.Evaluate(parsed.CanExecuteRaw, controller.GameLogic))
                 {
+                    var param = controller.CreateParameter(parsed);
                     controller.ExecuteActionImmediately(param);
                 }
                 nextTime = parsed.Interval > 0 ? parsed.Interval : EvaluateInterval();


### PR DESCRIPTION
## Summary
- avoid storing pre-computed parameters in `ScheduledAction`
- expose `CreateParameter` to generate action arguments
- use `CreateParameter` every interval so repeating actions use fresh values

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6841df23d7548330ac5d299183088e03