### PR TITLE
Fix decimal parsing in expression evaluator

### DIFF
--- a/Assets/Scripts/RuntimeScripts/IntExpressionEvaluator.cs
+++ b/Assets/Scripts/RuntimeScripts/IntExpressionEvaluator.cs
@@ -388,10 +388,33 @@ namespace RuntimeScripting
                     case ',': index++; return new Token(TokenType.Comma, ",");
                 }
 
-                if (char.IsDigit(c))
+                if (char.IsDigit(c) || (c == '.' && index + 1 < text.Length && char.IsDigit(text[index + 1])))
                 {
                     int start = index;
-                    while (index < text.Length && char.IsDigit(text[index])) index++;
+                    bool hasDot = false;
+                    if (c == '.')
+                    {
+                        hasDot = true;
+                        index++;
+                    }
+
+                    while (index < text.Length)
+                    {
+                        char nc = text[index];
+                        if (char.IsDigit(nc))
+                        {
+                            index++;
+                        }
+                        else if (nc == '.' && !hasDot)
+                        {
+                            hasDot = true;
+                            index++;
+                        }
+                        else
+                        {
+                            break;
+                        }
+                    }
                     return new Token(TokenType.Number, text.Substring(start, index - start));
                 }
 


### PR DESCRIPTION
## Summary
- support decimal numbers in `IntExpressionEvaluator` tokenization

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841fba35884833096a3c75b57bc60c4