### PR TITLE
Implement multiple actions per block-style DSL statement

### DIFF
--- a/Assets/Scripts/RuntimeScripts/ActionParameter.cs
+++ b/Assets/Scripts/RuntimeScripts/ActionParameter.cs
@@ -6,6 +6,8 @@ namespace RuntimeScripting
     public class ActionParameter
     {
         public ActionType ActionType;
+        public string FunctionName;
+        public System.Collections.Generic.List<string> Args = new System.Collections.Generic.List<string>();
         public string Targets;
         public string StringValue;
         public int IntValue;

--- a/Assets/Scripts/RuntimeScripts/ConditionEvaluator.cs
+++ b/Assets/Scripts/RuntimeScripts/ConditionEvaluator.cs
@@ -139,6 +139,12 @@ namespace RuntimeScripting
 
             private string ParseArgument()
             {
+                if (current.Type == TokenType.String)
+                {
+                    var val = current.Value;
+                    Advance();
+                    return val;
+                }
                 if (current.Type == TokenType.Number)
                 {
                     var val = current.Value;
@@ -328,6 +334,20 @@ namespace RuntimeScripting
                     case '-': index++; return new Token(TokenType.Minus, "-");
                     case '*': index++; return new Token(TokenType.Star, "*");
                     case '/': index++; return new Token(TokenType.Slash, "/");
+                    case '"':
+                        index++;
+                        int startStr = index;
+                        while (index < text.Length && text[index] != '"')
+                        {
+                            if (text[index] == '\\' && index + 1 < text.Length)
+                                index += 2;
+                            else
+                                index++;
+                        }
+                        string str = text.Substring(startStr, index - startStr);
+                        if (index < text.Length && text[index] == '"')
+                            index++;
+                        return new Token(TokenType.String, str);
                 }
 
                 if (c == '&' && Peek(1) == '&')
@@ -400,6 +420,7 @@ namespace RuntimeScripting
             EOF,
             Identifier,
             Number,
+            String,
             LParen,
             RParen,
             Comma,

--- a/Assets/Scripts/RuntimeScripts/IntExpressionEvaluator.cs
+++ b/Assets/Scripts/RuntimeScripts/IntExpressionEvaluator.cs
@@ -123,6 +123,13 @@ namespace RuntimeScripting
                 // Allow arithmetic expressions in argument positions and also
                 // support plain identifiers that represent string parameters.
 
+                if (current.Type == TokenType.String)
+                {
+                    var str = current.Value;
+                    Advance();
+                    return str;
+                }
+
                 if (current.Type == TokenType.Identifier)
                 {
                     var id = current.Value;
@@ -289,6 +296,12 @@ namespace RuntimeScripting
 
             private string ParseArgument()
             {
+                if (current.Type == TokenType.String)
+                {
+                    var str = current.Value;
+                    Advance();
+                    return str;
+                }
                 if (current.Type == TokenType.Identifier)
                 {
                     var id = current.Value;
@@ -386,6 +399,20 @@ namespace RuntimeScripting
                     case '(': index++; return new Token(TokenType.LParen, "(");
                     case ')': index++; return new Token(TokenType.RParen, ")");
                     case ',': index++; return new Token(TokenType.Comma, ",");
+                    case '"':
+                        index++;
+                        int startStr = index;
+                        while (index < text.Length && text[index] != '"')
+                        {
+                            if (text[index] == '\\' && index + 1 < text.Length)
+                                index += 2;
+                            else
+                                index++;
+                        }
+                        string str = text.Substring(startStr, index - startStr);
+                        if (index < text.Length && text[index] == '"')
+                            index++;
+                        return new Token(TokenType.String, str);
                 }
 
                 if (char.IsDigit(c) || (c == '.' && index + 1 < text.Length && char.IsDigit(text[index + 1])))
@@ -442,6 +469,7 @@ namespace RuntimeScripting
             EOF,
             Number,
             Identifier,
+            String,
             Plus,
             Minus,
             Star,

--- a/Assets/Scripts/RuntimeScripts/NewTextScriptParser.cs
+++ b/Assets/Scripts/RuntimeScripts/NewTextScriptParser.cs
@@ -194,10 +194,21 @@ namespace RuntimeScripting
                 var list = new List<ParsedAction>();
                 foreach (var act in actions)
                 {
-                    var pa = new ParsedAction
+                    var pa = new ParsedAction();
+                    if (TryParseActionType(act.name, out var at))
                     {
-                        ActionType = ParseActionType(act.name)
-                    };
+                        pa.ActionType = at;
+                    }
+                    else if (Enum.TryParse<FunctionInt>(act.name, out _) || Enum.TryParse<FunctionFloat>(act.name, out _))
+                    {
+                        pa.ActionType = ActionType.CallFunction;
+                        pa.FunctionName = act.name;
+                    }
+                    else
+                    {
+                        pa.ActionType = ActionType.CallFunction;
+                        pa.FunctionName = act.name;
+                    }
                     pa.Args.AddRange(act.args);
                     if (mods != null)
                     {
@@ -354,9 +365,9 @@ namespace RuntimeScripting
                 return dict;
             }
 
-            private ActionType ParseActionType(string name)
+            private bool TryParseActionType(string name, out ActionType at)
             {
-                return Enum.TryParse<ActionType>(name, out var at) ? at : ActionType.Attack;
+                return Enum.TryParse(name, out at);
             }
 
             private void ApplyCondition(ParsedAction pa)

--- a/Assets/Scripts/RuntimeScripts/NewTextScriptParser.cs
+++ b/Assets/Scripts/RuntimeScripts/NewTextScriptParser.cs
@@ -398,17 +398,24 @@ namespace RuntimeScripting
                 int start = index;
                 while (index < text.Length)
                 {
-                    char ch = text[index++];
+                    char ch = text[index];
                     if (ch == open)
+                    {
                         depth++;
+                    }
                     else if (ch == close)
                     {
                         depth--;
                         if (depth == 0)
-                            break;
+                        {
+                            // Do not consume the closing character so that caller can verify it
+                            return text.Substring(start, index - start);
+                        }
                     }
+                    index++;
                 }
-                return text.Substring(start, index - start - 1);
+                // If we reach here the text was malformed; return the remainder
+                return text.Substring(start);
             }
         }
     }

--- a/Assets/Scripts/RuntimeScripts/NewTextScriptParser.cs
+++ b/Assets/Scripts/RuntimeScripts/NewTextScriptParser.cs
@@ -1,0 +1,415 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace RuntimeScripting
+{
+    /// <summary>
+    /// Parses the block-style DSL with [Event] sections, if/else clauses and act/mod statements.
+    /// </summary>
+    public static class NewTextScriptParser
+    {
+        /// <summary>
+        /// Parses a script string written in the new DSL format.
+        /// </summary>
+        /// <param name="script">Full script text.</param>
+        /// <returns>Dictionary mapping event names to parsed events.</returns>
+        public static Dictionary<string, ParsedEvent> ParseString(string script)
+        {
+            var parser = new Parser(script);
+            return parser.Parse();
+        }
+
+        private class Parser
+        {
+            private readonly string text;
+            private int index;
+            private readonly Dictionary<string, ParsedEvent> events = new Dictionary<string, ParsedEvent>();
+            private readonly Stack<string> conditionStack = new Stack<string>();
+            private string currentEvent;
+
+            public Parser(string text)
+            {
+                this.text = text;
+            }
+
+            public Dictionary<string, ParsedEvent> Parse()
+            {
+                while (SkipWhite())
+                {
+                    if (Peek() == '[')
+                    {
+                        ParseEventSection();
+                    }
+                    else
+                    {
+                        // ignore unexpected characters
+                        index++;
+                    }
+                }
+
+                return events;
+            }
+
+            private void ParseEventSection()
+            {
+                Expect('[');
+                var name = ReadUntil(']');
+                Expect(']');
+                currentEvent = name.Trim();
+                if (!events.TryGetValue(currentEvent, out var pe))
+                {
+                    pe = new ParsedEvent { EventName = currentEvent };
+                    events.Add(currentEvent, pe);
+                }
+                SkipLine();
+                while (SkipWhite())
+                {
+                    if (StartsWith("["))
+                        break;
+                    if (StartsWith("if"))
+                    {
+                        ParseIfStatement(pe);
+                    }
+                    else if (StartsWith("act"))
+                    {
+                        var actions = ParseActStatement();
+                        foreach (var pa in actions)
+                        {
+                            ApplyCondition(pa);
+                            pe.Actions.Add(pa);
+                        }
+                    }
+                    else
+                    {
+                        // unknown or empty line
+                        SkipLine();
+                    }
+                }
+            }
+
+            private void ParseIfStatement(ParsedEvent pe)
+            {
+                ExpectString("if");
+                SkipWhite();
+                Expect('(');
+                var expr = ReadEnclosed('(', ')');
+                Expect(')');
+                SkipWhite();
+                Expect('{');
+                conditionStack.Push(expr.Trim());
+                SkipLine();
+                while (SkipWhite() && !StartsWith("}"))
+                {
+                    if (StartsWith("if"))
+                    {
+                        ParseIfStatement(pe);
+                    }
+                    else if (StartsWith("act"))
+                    {
+                        var actions = ParseActStatement();
+                        foreach (var pa in actions)
+                        {
+                            ApplyCondition(pa);
+                            pe.Actions.Add(pa);
+                        }
+                    }
+                    else
+                    {
+                        SkipLine();
+                    }
+                }
+                Expect('}');
+                conditionStack.Pop();
+                SkipWhite();
+                // else or else if
+                if (StartsWith("else"))
+                {
+                    ExpectString("else");
+                    SkipWhite();
+                    string cond = null;
+                    if (StartsWith("if"))
+                    {
+                        ExpectString("if");
+                        SkipWhite();
+                        Expect('(');
+                        cond = ReadEnclosed('(', ')');
+                        Expect(')');
+                        conditionStack.Push($"!({expr.Trim()}) && ({cond.Trim()})");
+                    }
+                    else
+                    {
+                        conditionStack.Push($"!({expr.Trim()})");
+                    }
+                    SkipWhite();
+                    Expect('{');
+                    SkipLine();
+                    while (SkipWhite() && !StartsWith("}"))
+                    {
+                        if (StartsWith("if"))
+                        {
+                            ParseIfStatement(pe);
+                        }
+                        else if (StartsWith("act"))
+                        {
+                            var actions = ParseActStatement();
+                            foreach (var pa in actions)
+                            {
+                                ApplyCondition(pa);
+                                pe.Actions.Add(pa);
+                            }
+                        }
+                        else
+                        {
+                            SkipLine();
+                        }
+                    }
+                    Expect('}');
+                    conditionStack.Pop();
+                }
+            }
+
+            private List<ParsedAction> ParseActStatement()
+            {
+                ExpectString("act");
+                SkipWhite();
+                Expect('{');
+                var actionsContent = ReadEnclosed('{', '}');
+                Expect('}');
+                var actions = ParseActionList(actionsContent);
+                SkipWhite();
+                Dictionary<string, string> mods = null;
+                if (StartsWith("mod"))
+                {
+                    ExpectString("mod");
+                    SkipWhite();
+                    Expect('{');
+                    var modContent = ReadEnclosed('{', '}');
+                    Expect('}');
+                    mods = ParseModifierList(modContent);
+                }
+                Expect(';');
+                SkipLine();
+
+                var list = new List<ParsedAction>();
+                foreach (var act in actions)
+                {
+                    var pa = new ParsedAction
+                    {
+                        ActionType = ParseActionType(act.name)
+                    };
+                    pa.Args.AddRange(act.args);
+                    if (mods != null)
+                    {
+                        if (mods.TryGetValue("interval", out var iv))
+                        {
+                            if (float.TryParse(iv, out var interval))
+                                pa.Interval = interval;
+                            else
+                                pa.IntervalFuncRaw = iv;
+                        }
+                        if (mods.TryGetValue("period", out var pd))
+                        {
+                            if (float.TryParse(pd, out var period))
+                                pa.Period = period;
+                            else
+                                pa.PeriodFuncRaw = pd;
+                        }
+                        if (mods.TryGetValue("canExecute", out var ce))
+                            pa.CanExecuteRaw = ce;
+                        if (mods.TryGetValue("intervalFunc", out var ivf))
+                            pa.IntervalFuncRaw = ivf;
+                    }
+                    list.Add(pa);
+                }
+                return list;
+            }
+
+            private List<(string name, List<string> args)> ParseActionList(string text)
+            {
+                var list = new List<(string, List<string>)>();
+                int depth = 0;
+                int start = 0;
+                for (int i = 0; i <= text.Length; i++)
+                {
+                    if (i == text.Length || (text[i] == ',' && depth == 0))
+                    {
+                        var part = text.Substring(start, i - start).Trim();
+                        if (part.Length > 0)
+                        {
+                            list.Add(ParseActionExpr(part));
+                        }
+                        start = i + 1;
+                    }
+                    else if (text[i] == '(')
+                        depth++;
+                    else if (text[i] == ')')
+                        depth--;
+                }
+                return list;
+            }
+
+            private (string name, List<string> args) ParseActionExpr(string text)
+            {
+                int open = text.IndexOf('(');
+                string name = open >= 0 ? text.Substring(0, open).Trim() : text.Trim();
+                var args = new List<string>();
+                if (open >= 0)
+                {
+                    int close = text.LastIndexOf(')');
+                    if (close > open)
+                    {
+                        var argContent = text.Substring(open + 1, close - open - 1);
+                        args = ParseArgList(argContent);
+                    }
+                }
+                return (name, args);
+            }
+
+            private List<string> ParseArgList(string text)
+            {
+                var list = new List<string>();
+                int depth = 0;
+                int start = 0;
+                for (int i = 0; i <= text.Length; i++)
+                {
+                    if (i == text.Length || (text[i] == ',' && depth == 0))
+                    {
+                        var part = text.Substring(start, i - start).Trim();
+                        if (part.Length > 0)
+                            list.Add(part);
+                        start = i + 1;
+                    }
+                    else if (text[i] == '(')
+                        depth++;
+                    else if (text[i] == ')')
+                        depth--;
+                }
+                return list;
+            }
+
+            private Dictionary<string, string> ParseModifierList(string text)
+            {
+                var dict = new Dictionary<string, string>();
+                int depth = 0;
+                int start = 0;
+                for (int i = 0; i <= text.Length; i++)
+                {
+                    if (i == text.Length || (text[i] == ',' && depth == 0))
+                    {
+                        var part = text.Substring(start, i - start).Trim();
+                        if (part.Length > 0)
+                        {
+                            int eq = part.IndexOf('=');
+                            if (eq > 0)
+                            {
+                                string key = part.Substring(0, eq).Trim();
+                                string value = part.Substring(eq + 1).Trim();
+                                dict[key] = value;
+                            }
+                        }
+                        start = i + 1;
+                    }
+                    else if (text[i] == '(')
+                        depth++;
+                    else if (text[i] == ')')
+                        depth--;
+                }
+                return dict;
+            }
+
+            private ActionType ParseActionType(string name)
+            {
+                return Enum.TryParse<ActionType>(name, out var at) ? at : ActionType.Attack;
+            }
+
+            private void ApplyCondition(ParsedAction pa)
+            {
+                if (conditionStack.Count == 0)
+                    return;
+                var sb = new StringBuilder();
+                foreach (var cond in conditionStack)
+                {
+                    if (sb.Length > 0) sb.Insert(0, "(").Append(") && ");
+                    sb.Insert(0, cond);
+                }
+                pa.Condition = sb.ToString();
+            }
+
+            // Helper reading utilities
+            private char Peek()
+            {
+                if (index >= text.Length) return '\0';
+                return text[index];
+            }
+
+            private bool StartsWith(string s)
+            {
+                SkipWhite();
+                return string.Compare(text, index, s, 0, s.Length, StringComparison.Ordinal) == 0;
+            }
+
+            private bool SkipWhite()
+            {
+                bool moved = false;
+                while (index < text.Length && char.IsWhiteSpace(text[index]))
+                {
+                    index++;
+                    moved = true;
+                }
+                return index < text.Length;
+            }
+
+            private void SkipLine()
+            {
+                while (index < text.Length && text[index] != '\n') index++;
+                if (index < text.Length) index++;
+            }
+
+            private void Expect(char c)
+            {
+                SkipWhite();
+                if (index >= text.Length || text[index] != c)
+                    throw new Exception($"Expected '{c}' at {index}");
+                index++;
+            }
+
+            private void ExpectString(string s)
+            {
+                SkipWhite();
+                for (int i = 0; i < s.Length; i++)
+                {
+                    if (index + i >= text.Length || text[index + i] != s[i])
+                        throw new Exception($"Expected '{s}' at {index}");
+                }
+                index += s.Length;
+            }
+
+            private string ReadUntil(char c)
+            {
+                int start = index;
+                while (index < text.Length && text[index] != c) index++;
+                return text.Substring(start, index - start);
+            }
+
+            private string ReadEnclosed(char open, char close)
+            {
+                int depth = 1;
+                int start = index;
+                while (index < text.Length)
+                {
+                    char ch = text[index++];
+                    if (ch == open)
+                        depth++;
+                    else if (ch == close)
+                    {
+                        depth--;
+                        if (depth == 0)
+                            break;
+                    }
+                }
+                return text.Substring(start, index - start - 1);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/RuntimeScripts/NewTextScriptParser.cs
+++ b/Assets/Scripts/RuntimeScripts/NewTextScriptParser.cs
@@ -302,7 +302,7 @@ namespace RuntimeScripting
                     {
                         var part = text.Substring(start, i - start).Trim();
                         if (part.Length > 0)
-                            list.Add(part);
+                            list.Add(Unquote(part));
                         start = i + 1;
                     }
                     else if (!inString && text[i] == '(')
@@ -342,7 +342,7 @@ namespace RuntimeScripting
                             {
                                 string key = part.Substring(0, eq).Trim();
                                 string value = part.Substring(eq + 1).Trim();
-                                dict[key] = value;
+                                dict[key] = Unquote(value);
                             }
                         }
                         start = i + 1;
@@ -491,6 +491,19 @@ namespace RuntimeScripting
 
                 // If we reach here the text was malformed; return the remainder
                 return text.Substring(start);
+            }
+
+            private static string Unquote(string value)
+            {
+                if (value.Length >= 2)
+                {
+                    if ((value[0] == '"' && value[value.Length - 1] == '"') ||
+                        (value[0] == '\'' && value[value.Length - 1] == '\''))
+                    {
+                        return value.Substring(1, value.Length - 2);
+                    }
+                }
+                return value;
             }
         }
     }

--- a/Assets/Scripts/RuntimeScripts/ParsedAction.cs
+++ b/Assets/Scripts/RuntimeScripts/ParsedAction.cs
@@ -8,6 +8,7 @@ namespace RuntimeScripting
     public class ParsedAction
     {
         public ActionType ActionType { get; set; }
+        public string FunctionName { get; set; }
         public List<string> Args { get; } = new List<string>();
         public float Interval { get; set; }
         public float Period { get; set; }
@@ -28,6 +29,7 @@ namespace RuntimeScripting
         RemoveRandomDebuffPlayerEffect,
         AddMaxHp,
         SetNanikaEffectFor,
-        SpawnNanika
+        SpawnNanika,
+        CallFunction
     }
 }

--- a/Assets/Scripts/RuntimeScripts/RuntimeTextScriptController.cs
+++ b/Assets/Scripts/RuntimeScripts/RuntimeTextScriptController.cs
@@ -32,6 +32,28 @@ namespace RuntimeScripting
         }
 
         /// <summary>
+        /// Loads all script files written in the new DSL from a Resources folder.
+        /// </summary>
+        /// <param name="folder">Resources subfolder containing the scripts.</param>
+        public void LoadV2(string folder)
+        {
+            var loaded = new Dictionary<string, ParsedEvent>();
+            var assets = Resources.LoadAll<TextAsset>(folder);
+            foreach (var asset in assets)
+            {
+                var parsed = NewTextScriptParser.ParseString(asset.text);
+                foreach (var kv in parsed)
+                {
+                    if (!loaded.ContainsKey(kv.Key))
+                        loaded[kv.Key] = kv.Value;
+                    else
+                        loaded[kv.Key].Actions.AddRange(kv.Value.Actions);
+                }
+            }
+            MergeEvents(loaded);
+        }
+
+        /// <summary>
         /// Loads a single script file from the Resources folder.
         /// </summary>
         /// <param name="path">Resource path of the script without extension.</param>
@@ -42,12 +64,37 @@ namespace RuntimeScripting
         }
 
         /// <summary>
+        /// Loads a single script file written in the new DSL from the Resources folder.
+        /// </summary>
+        /// <param name="path">Resource path of the script without extension.</param>
+        public void LoadFileV2(string path)
+        {
+            if (path.EndsWith(".txt"))
+                path = path.Substring(0, path.Length - 4);
+            var asset = Resources.Load<TextAsset>(path);
+            if (asset == null)
+                return;
+            var parsed = NewTextScriptParser.ParseString(asset.text);
+            MergeEvents(parsed);
+        }
+
+        /// <summary>
         /// Loads script events from a string.
         /// </summary>
         /// <param name="script">Script contents in the DSL format.</param>
         public void LoadFromString(string script)
         {
             var loaded = TextScriptParser.ParseString(script);
+            MergeEvents(loaded);
+        }
+
+        /// <summary>
+        /// Loads events from a string written in the new block-style DSL.
+        /// </summary>
+        /// <param name="script">Script contents in the new DSL format.</param>
+        public void LoadFromStringV2(string script)
+        {
+            var loaded = NewTextScriptParser.ParseString(script);
             MergeEvents(loaded);
         }
 

--- a/Assets/Scripts/RuntimeScripts/RuntimeTextScriptController.cs
+++ b/Assets/Scripts/RuntimeScripts/RuntimeTextScriptController.cs
@@ -166,6 +166,9 @@ namespace RuntimeScripting
                 case ActionType.SpawnNanika:
                     GameLogic.SpawnNanika(param.Targets, param.StringValue, param.IntValue);
                     break;
+                case ActionType.CallFunction:
+                    GameLogic.EvaluateFunctionFloat(param.FunctionName, param.Args.ToArray());
+                    break;
             }
         }
 
@@ -227,6 +230,10 @@ namespace RuntimeScripting
                         param.StringValue = pa.Args[1];
                     if (pa.Args.Count > 2)
                         param.IntValue = ParseIntArg(pa.Args[2]);
+                    break;
+                case ActionType.CallFunction:
+                    param.FunctionName = pa.FunctionName;
+                    param.Args.AddRange(pa.Args);
                     break;
                 default:
                     if (pa.Args.Count > 0)

--- a/Assets/Scripts/RuntimeScripts/TextScriptParser.cs
+++ b/Assets/Scripts/RuntimeScripts/TextScriptParser.cs
@@ -122,11 +122,22 @@ namespace RuntimeScripting
 
             var options = ParseOptions(optionsPart);
 
-            var pa = new ParsedAction
+            var pa = new ParsedAction();
+            if (TryParseActionType(name, out var at))
             {
-                ActionType = ParseActionType(name),
-                Condition = condition
-            };
+                pa.ActionType = at;
+            }
+            else if (Enum.TryParse<FunctionInt>(name, out _) || Enum.TryParse<FunctionFloat>(name, out _))
+            {
+                pa.ActionType = ActionType.CallFunction;
+                pa.FunctionName = name;
+            }
+            else
+            {
+                pa.ActionType = ActionType.CallFunction;
+                pa.FunctionName = name;
+            }
+            pa.Condition = condition;
             pa.Args.AddRange(args);
             if (options.TryGetValue("interval", out var iv))
             {
@@ -181,9 +192,9 @@ namespace RuntimeScripting
             return false;
         }
 
-        private static ActionType ParseActionType(string name)
+        private static bool TryParseActionType(string name, out ActionType at)
         {
-            return Enum.TryParse<ActionType>(name, out var at) ? at : ActionType.Attack;
+            return Enum.TryParse(name, out at);
         }
 
         private static Dictionary<string, string> ParseOptions(string text)


### PR DESCRIPTION
## Summary
- support returning multiple ParsedAction objects from `NewTextScriptParser`
- hook up multiple-action results when parsing event sections
- revert README changes

## Testing
- `mcs -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684230aaec8c833099f4315ddc8fade2