### PR TITLE
Centralize action parameter parsing

### DIFF
--- a/Assets/Scripts/RuntimeScripts/ActionParameter.cs
+++ b/Assets/Scripts/RuntimeScripts/ActionParameter.cs
@@ -8,9 +8,5 @@ namespace RuntimeScripting
         public ActionType ActionType;
         public string FunctionName;
         public System.Collections.Generic.List<string> Args = new System.Collections.Generic.List<string>();
-        public string Targets;
-        public string StringValue;
-        public int IntValue;
-        public int ExtraValue;
     }
 }

--- a/Assets/Scripts/RuntimeScripts/FunctionEnums.cs
+++ b/Assets/Scripts/RuntimeScripts/FunctionEnums.cs
@@ -2,25 +2,5 @@ using System;
 
 namespace RuntimeScripting
 {
-    /// <summary>
-    /// Functions returning integer values.
-    /// </summary>
-    public enum FunctionInt
-    {
-        HpMin,
-        ComboCount,
-        Shield,
-        NanikaCount,
-        ResourceCount,
-        UseResource,
-    }
-
-    /// <summary>
-    /// Functions returning floating point values.
-    /// </summary>
-    public enum FunctionFloat
-    {
-        Interval,
-        Double
-    }
+    
 }

--- a/Assets/Scripts/RuntimeScripts/GameLogic.cs
+++ b/Assets/Scripts/RuntimeScripts/GameLogic.cs
@@ -133,5 +133,71 @@ namespace RuntimeScripting
         {
             Debug.Log($"Spawn nanika {nanikaId} at {spawnPosId} for {targets}");
         }
+
+        /// <summary>
+        /// Creates an executable parameter object from a parsed action.
+        /// </summary>
+        /// <param name="pa">Parsed action.</param>
+        /// <returns>Parameter instance.</returns>
+        internal ActionParameter CreateParameter(ParsedAction pa)
+        {
+            var param = new ActionParameter
+            {
+                ActionType = pa.ActionType,
+                FunctionName = pa.FunctionName
+            };
+            param.Args.AddRange(pa.Args);
+            return param;
+        }
+
+        /// <summary>
+        /// Executes a pre-parsed action.
+        /// </summary>
+        /// <param name="param">Action parameter.</param>
+        internal void ExecuteAction(ActionParameter param)
+        {
+            switch (param.ActionType)
+            {
+                case ActionType.Attack:
+                    if (param.Args.Count > 0)
+                        Attack(ParseIntArg(param.Args[0]));
+                    break;
+                case ActionType.AddPlayerEffect:
+                    if (param.Args.Count > 2)
+                        AddPlayerEffect(param.Args[0], param.Args[1], ParseIntArg(param.Args[2]));
+                    break;
+                case ActionType.AddPlayerEffectFor:
+                    if (param.Args.Count > 3)
+                        AddPlayerEffectFor(param.Args[0], param.Args[1], ParseIntArg(param.Args[2]), ParseIntArg(param.Args[3]));
+                    break;
+                case ActionType.RemoveRandomDebuffPlayerEffect:
+                    if (param.Args.Count > 1)
+                        RemoveRandomDebuffPlayerEffect(param.Args[0], ParseIntArg(param.Args[1]));
+                    break;
+                case ActionType.AddMaxHp:
+                    if (param.Args.Count > 1)
+                        AddMaxHp(param.Args[0], ParseIntArg(param.Args[1]));
+                    break;
+                case ActionType.SetNanikaEffectFor:
+                    if (param.Args.Count > 2)
+                        SetNanikaEffectFor(param.Args[0], param.Args[1], ParseIntArg(param.Args[2]));
+                    break;
+                case ActionType.SpawnNanika:
+                    if (param.Args.Count > 2)
+                        SpawnNanika(param.Args[0], param.Args[1], ParseIntArg(param.Args[2]));
+                    break;
+                case ActionType.CallFunction:
+                    EvaluateFunctionFloat(param.FunctionName, param.Args.ToArray());
+                    break;
+            }
+        }
+
+        private int ParseIntArg(string arg)
+        {
+            if (int.TryParse(arg, out var value))
+                return value;
+
+            return IntExpressionEvaluator.Evaluate(arg, this);
+        }
     }
 }

--- a/Assets/Scripts/RuntimeScripts/GameLogic.cs
+++ b/Assets/Scripts/RuntimeScripts/GameLogic.cs
@@ -200,4 +200,41 @@ namespace RuntimeScripting
             return IntExpressionEvaluator.Evaluate(arg, this);
         }
     }
+    
+    /// <summary>
+    /// Enumeration of built-in action types.
+    /// </summary>
+    public enum ActionType
+    {
+        Attack,
+        AddPlayerEffect,
+        AddPlayerEffectFor,
+        RemoveRandomDebuffPlayerEffect,
+        AddMaxHp,
+        SetNanikaEffectFor,
+        SpawnNanika,
+        CallFunction
+    }
+    
+    /// <summary>
+    /// Functions returning integer values.
+    /// </summary>
+    public enum FunctionInt
+    {
+        HpMin,
+        ComboCount,
+        Shield,
+        NanikaCount,
+        ResourceCount,
+        UseResource,
+    }
+
+    /// <summary>
+    /// Functions returning floating point values.
+    /// </summary>
+    public enum FunctionFloat
+    {
+        Interval,
+        Double
+    }
 }

--- a/Assets/Scripts/RuntimeScripts/ParsedAction.cs
+++ b/Assets/Scripts/RuntimeScripts/ParsedAction.cs
@@ -26,19 +26,4 @@ namespace RuntimeScripting
         /// </summary>
         public string WhileRaw { get; set; }
     }
-
-    /// <summary>
-    /// Enumeration of built-in action types.
-    /// </summary>
-    public enum ActionType
-    {
-        Attack,
-        AddPlayerEffect,
-        AddPlayerEffectFor,
-        RemoveRandomDebuffPlayerEffect,
-        AddMaxHp,
-        SetNanikaEffectFor,
-        SpawnNanika,
-        CallFunction
-    }
 }

--- a/Assets/Scripts/RuntimeScripts/RuntimeTextScriptController.cs
+++ b/Assets/Scripts/RuntimeScripts/RuntimeTextScriptController.cs
@@ -99,8 +99,8 @@ namespace RuntimeScripting
                 }
                 else
                 {
-                    var param = CreateParameter(pa);
-                    ExecuteActionImmediately(param);
+                    var param = GameLogic.CreateParameter(pa);
+                    GameLogic.ExecuteAction(param);
                 }
             }
         }
@@ -111,121 +111,6 @@ namespace RuntimeScripting
             scheduled.Remove(sa);
         }
 
-        internal void ExecuteActionImmediately(ActionParameter param)
-        {
-            switch (param.ActionType)
-            {
-                case ActionType.Attack:
-                    GameLogic.Attack(param.IntValue);
-                    break;
-                case ActionType.AddPlayerEffect:
-                    GameLogic.AddPlayerEffect(param.Targets, param.StringValue, param.IntValue);
-                    break;
-                case ActionType.AddPlayerEffectFor:
-                    GameLogic.AddPlayerEffectFor(param.Targets, param.StringValue, param.IntValue, param.ExtraValue);
-                    break;
-                case ActionType.RemoveRandomDebuffPlayerEffect:
-                    GameLogic.RemoveRandomDebuffPlayerEffect(param.Targets, param.IntValue);
-                    break;
-                case ActionType.AddMaxHp:
-                    GameLogic.AddMaxHp(param.Targets, param.IntValue);
-                    break;
-                case ActionType.SetNanikaEffectFor:
-                    GameLogic.SetNanikaEffectFor(param.Targets, param.StringValue, param.IntValue);
-                    break;
-                case ActionType.SpawnNanika:
-                    GameLogic.SpawnNanika(param.Targets, param.StringValue, param.IntValue);
-                    break;
-                case ActionType.CallFunction:
-                    GameLogic.EvaluateFunctionFloat(param.FunctionName, param.Args.ToArray());
-                    break;
-            }
-        }
-
-        internal ActionParameter CreateParameter(ParsedAction pa)
-        {
-            var param = new ActionParameter
-            {
-                ActionType = pa.ActionType
-            };
-
-            switch (pa.ActionType)
-            {
-                case ActionType.Attack:
-                    if (pa.Args.Count > 0)
-                        param.IntValue = ParseIntArg(pa.Args[0]);
-                    break;
-                case ActionType.AddPlayerEffect:
-                    if (pa.Args.Count > 0)
-                        param.Targets = pa.Args[0];
-                    if (pa.Args.Count > 1)
-                        param.StringValue = pa.Args[1];
-                    if (pa.Args.Count > 2)
-                        param.IntValue = ParseIntArg(pa.Args[2]);
-                    break;
-                case ActionType.AddPlayerEffectFor:
-                    if (pa.Args.Count > 0)
-                        param.Targets = pa.Args[0];
-                    if (pa.Args.Count > 1)
-                        param.StringValue = pa.Args[1];
-                    if (pa.Args.Count > 2)
-                        param.IntValue = ParseIntArg(pa.Args[2]);
-                    if (pa.Args.Count > 3)
-                        param.ExtraValue = ParseIntArg(pa.Args[3]);
-                    break;
-                case ActionType.RemoveRandomDebuffPlayerEffect:
-                    if (pa.Args.Count > 0)
-                        param.Targets = pa.Args[0];
-                    if (pa.Args.Count > 1)
-                        param.IntValue = ParseIntArg(pa.Args[1]);
-                    break;
-                case ActionType.AddMaxHp:
-                    if (pa.Args.Count > 0)
-                        param.Targets = pa.Args[0];
-                    if (pa.Args.Count > 1)
-                        param.IntValue = ParseIntArg(pa.Args[1]);
-                    break;
-                case ActionType.SetNanikaEffectFor:
-                    if (pa.Args.Count > 0)
-                        param.Targets = pa.Args[0];
-                    if (pa.Args.Count > 1)
-                        param.StringValue = pa.Args[1];
-                    if (pa.Args.Count > 2)
-                        param.IntValue = ParseIntArg(pa.Args[2]);
-                    break;
-                case ActionType.SpawnNanika:
-                    if (pa.Args.Count > 0)
-                        param.Targets = pa.Args[0];
-                    if (pa.Args.Count > 1)
-                        param.StringValue = pa.Args[1];
-                    if (pa.Args.Count > 2)
-                        param.IntValue = ParseIntArg(pa.Args[2]);
-                    break;
-                case ActionType.CallFunction:
-                    param.FunctionName = pa.FunctionName;
-                    param.Args.AddRange(pa.Args);
-                    break;
-                default:
-                    if (pa.Args.Count > 0)
-                        param.Targets = pa.Args[0];
-                    if (pa.Args.Count > 1)
-                        param.StringValue = pa.Args[1];
-                    if (pa.Args.Count > 2)
-                        param.IntValue = ParseIntArg(pa.Args[2]);
-                    if (pa.Args.Count > 3)
-                        param.ExtraValue = ParseIntArg(pa.Args[3]);
-                    break;
-            }
-
-            return param;
-        }
-
-        private int ParseIntArg(string arg)
-        {
-            if (int.TryParse(arg, out var value))
-                return value;
-
-            return IntExpressionEvaluator.Evaluate(arg, GameLogic);
-        }
+        
     }
 }

--- a/Assets/Scripts/RuntimeScripts/ScheduledAction.cs
+++ b/Assets/Scripts/RuntimeScripts/ScheduledAction.cs
@@ -43,8 +43,8 @@ namespace RuntimeScripting
                 if (string.IsNullOrEmpty(parsed.CanExecuteRaw) ||
                     ConditionEvaluator.Evaluate(parsed.CanExecuteRaw, controller.GameLogic))
                 {
-                    var param = controller.CreateParameter(parsed);
-                    controller.ExecuteActionImmediately(param);
+                    var param = controller.GameLogic.CreateParameter(parsed);
+                    controller.GameLogic.ExecuteAction(param);
                     executedCount++;
                 }
 


### PR DESCRIPTION
## Summary
- simplify `ActionParameter` to only store action metadata
- move parameter creation and execution logic into `GameLogic`
- update controller and scheduler to use the new `GameLogic` methods

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68431591839083309c6b093c25dc55ca