### PR TITLE
Fix arithmetic evaluation in condition parsing

### DIFF
--- a/Assets/Scripts/RuntimeScripts/ConditionEvaluator.cs
+++ b/Assets/Scripts/RuntimeScripts/ConditionEvaluator.cs
@@ -111,6 +111,12 @@ namespace RuntimeScripting
                 {
                     var v = float.Parse(current.Value, CultureInfo.InvariantCulture);
                     Advance();
+
+                    // Numbers can participate in arithmetic expressions such as
+                    // "2 + 2 * 2" within a condition. Continue parsing any
+                    // pending operators before returning the final value.
+                    v = ContinueTerm(v);
+                    v = ContinueExpression(v);
                     return v;
                 }
                 else if (current.Type == TokenType.Identifier)


### PR DESCRIPTION
## Summary
- handle arithmetic expressions starting with numbers inside conditions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846f565348c8330b545633e175f0079