### PR TITLE
Fix parser newline requirements

### DIFF
--- a/Assets/Scripts/RuntimeScripts/TextScriptParser.cs
+++ b/Assets/Scripts/RuntimeScripts/TextScriptParser.cs
@@ -99,7 +99,7 @@ namespace RuntimeScripting
                 Expect('{');
                 var accumulated = expr.Trim();
                 conditionStack.Push(accumulated);
-                SkipLine();
+                SkipWhite();
                 while (SkipWhite() && !StartsWith("}"))
                 {
                     if (StartsWith("if"))
@@ -149,7 +149,7 @@ namespace RuntimeScripting
                     }
                     SkipWhite();
                     Expect('{');
-                    SkipLine();
+                    SkipWhite();
                     while (SkipWhite() && !StartsWith("}"))
                     {
                         if (StartsWith("if"))
@@ -199,7 +199,7 @@ namespace RuntimeScripting
                     mods = ParseModifierList(modContent);
                 }
                 Expect(';');
-                SkipLine();
+                SkipWhite();
 
                 var list = new List<ParsedAction>();
                 foreach (var act in actions)


### PR DESCRIPTION
## Summary
- relax newline requirements in `TextScriptParser`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68472ac09f28833097e2771612300fc2