### PR TITLE
Add immediate action execution method

### DIFF
--- a/Assets/Scripts/RuntimeScripting/RuntimeTextScriptController.cs
+++ b/Assets/Scripts/RuntimeScripting/RuntimeTextScriptController.cs
@@ -83,7 +83,29 @@ namespace RuntimeScripting
         {
             if (!_events.TryGetValue(eventName, out var parsedEvent)) return;
 
-            foreach (var action in parsedEvent.Actions)
+            ExecuteActions(parsedEvent.Actions);
+        }
+
+        /// <summary>
+        /// Executes DSL text that contains only action statements without an event block.
+        /// </summary>
+        /// <param name="script">The raw DSL text.</param>
+        public void ExecuteString(string script)
+        {
+            if (string.IsNullOrWhiteSpace(script)) return;
+
+            const string tempEvent = "OnImmediate";
+            var wrapped = $"[{tempEvent}]\n" + script;
+            var parsed = TextScriptParser.ParseString(wrapped);
+            if (parsed.TryGetValue(tempEvent, out var evt))
+            {
+                ExecuteActions(evt.Actions);
+            }
+        }
+
+        private void ExecuteActions(List<ParsedAction> actions)
+        {
+            foreach (var action in actions)
             {
                 if (!string.IsNullOrEmpty(action.Condition) &&
                     !GameLogic.EvaluateCondition(action.Condition))

--- a/Assets/Scripts/RuntimeScripting/RuntimeTextScriptController.cs
+++ b/Assets/Scripts/RuntimeScripting/RuntimeTextScriptController.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Text;
 using UnityEngine;
 
 namespace RuntimeScripting
@@ -101,6 +102,35 @@ namespace RuntimeScripting
             {
                 ExecuteActions(evt.Actions);
             }
+        }
+
+        public void ExecuteEasyScript(string easyScript)
+        {
+            ExecuteString(FormatAction(easyScript));
+        }
+
+        private static string FormatAction(string input)
+        {
+            var parts = input.Split(':');
+
+            var actBody  = parts.Length > 0 ? parts[0] : string.Empty;
+            var interval = parts.Length > 1 ? parts[1] : string.Empty;
+            var period   = parts.Length > 2 ? parts[2] : string.Empty;
+            var maxCount = parts.Length > 3 ? parts[3] : string.Empty;
+
+            var sb = new StringBuilder();
+            sb.Append($"act {{ {actBody} }} mod {{ ");
+
+            if (!string.IsNullOrEmpty(interval))
+                sb.Append($"interval = {interval}, ");
+            if (!string.IsNullOrEmpty(period))
+                sb.Append($"period = {period}, ");
+            if (!string.IsNullOrEmpty(maxCount))
+                sb.Append($"maxCount = {maxCount}");
+
+            sb.Append(" };");
+
+            return sb.ToString();
         }
 
         private void ExecuteActions(List<ParsedAction> actions)


### PR DESCRIPTION
## Summary
- add `ExecuteString` to `RuntimeTextScriptController` for running actions that aren't wrapped in an event block
- refactor action processing into a private `ExecuteActions` helper

## Testing
- `git diff --unified=0`

------
https://chatgpt.com/codex/tasks/task_e_6849e064a0bc8330a266358f95ee04aa