### PR TITLE
Fix interval expression parsing

### DIFF
--- a/Assets/Scripts/RuntimeScripting/ActionTokenizer.cs
+++ b/Assets/Scripts/RuntimeScripting/ActionTokenizer.cs
@@ -27,6 +27,10 @@ namespace RuntimeScripting
                 case ')': Advance(); return new ActionToken(ActionTokenType.RParen, ")");
                 case ',': Advance(); return new ActionToken(ActionTokenType.Comma, ",");
                 case '=': Advance(); return new ActionToken(ActionTokenType.Assign, "=");
+                case '+': Advance(); return new ActionToken(ActionTokenType.Plus, "+");
+                case '-': Advance(); return new ActionToken(ActionTokenType.Minus, "-");
+                case '*': Advance(); return new ActionToken(ActionTokenType.Star, "*");
+                case '/': Advance(); return new ActionToken(ActionTokenType.Slash, "/");
                 case '"':
                 case '\'':
                     return ReadString();
@@ -73,7 +77,11 @@ namespace RuntimeScripting
         LParen,
         RParen,
         Comma,
-        Assign
+        Assign,
+        Plus,
+        Minus,
+        Star,
+        Slash
     }
 
     internal readonly struct ActionToken


### PR DESCRIPTION
## Summary
- add operator tokens to `ActionTokenizer`
- revert accidental README change

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684b8f1b0670833089c0a78fb46faced